### PR TITLE
sensible specs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,9 +1,6 @@
 [
-  inputs: [
-    "test/**/*.{ex,exs}",
-    "lib/**/*.{ex,exs}",
-    "config/**/*.exs",
-    "mix.exs"
-  ],
-  line_length: 80,
+  import_deps: [:ecto],
+  inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  subdirectories: ["priv/*/migrations"],
+  line_length: 80
 ]

--- a/lib/maestro/aggregate/command_handler.ex
+++ b/lib/maestro/aggregate/command_handler.ex
@@ -6,7 +6,7 @@ defmodule Maestro.Aggregate.CommandHandler do
 
   @type root :: Maestro.Aggregate.Root.t()
   @type command :: Maestro.Types.Command.t()
-  @type event :: Maestro.Types.Event.t()
+  @type uncommitted_event :: Maestro.Types.Event.uncommitted()
 
   @doc """
   Command handlers in maestro should implement an `eval` function that expects
@@ -15,5 +15,5 @@ defmodule Maestro.Aggregate.CommandHandler do
   raise an error which can be used to short circuit the command processing
   cycle.
   """
-  @callback eval(root(), command()) :: [event()]
+  @callback eval(root(), command()) :: [uncommitted_event()]
 end

--- a/lib/maestro/types/event.ex
+++ b/lib/maestro/types/event.ex
@@ -27,6 +27,17 @@ defmodule Maestro.Types.Event do
           body: map()
         }
 
+  # timestamp and sequence are nil since command handlers don't generate HLC's
+  # or decide sequence numbers; the database doesn't actually allow these to be
+  # nil outside of this particular use case
+  @type uncommitted :: %__MODULE__{
+          aggregate_id: aggregate_id(),
+          type: String.t(),
+          body: map(),
+          timestamp: nil,
+          sequence: nil
+        }
+
   @primary_key false
   schema "event_log" do
     field(:timestamp, Ecto.HLClock, primary_key: true)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Maestro.Mixfile do
   use Mix.Project
 
-  @version "0.3.1"
+  @version "0.3.2"
   @source_url "https://github.com/toniqsystems/maestro"
 
   def project do


### PR DESCRIPTION
Integrating `{:maestro, "~> 0.3"}` found a problem with the command handler callback spec; I have made a separate, sufficiently relaxed spec for events for the command handler return type only.

This won't affect projections since they only see the prepared version of the events which includes the timestamp and sequence number. Similarly, event handlers are after persistence, so these fields are required by then.