### PR TITLE
Added Jason dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule Maestro.Mixfile do
       {:ecto_sql, "~> 3.0"},
       {:postgrex, ">= 0.0.0"},
       {:ecto_hlclock, "~> 0.1"},
+      {:jason, "~> 1.1"},
       {:mock, "~> 0.3", only: :test, runtime: false},
       {:credo, "~> 1.0", only: [:dev, :test]},
       {:stream_data, "~> 0.3", only: [:test]},


### PR DESCRIPTION
An error is triggered when following the example on the Readme.

```Elixir
Interactive Elixir (1.8.2) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> {:ok, id} = EsCqrsMaestro.Counter.new()
{:ok, %HLClock.Timestamp{counter: 0, node_id: 88558817, time: 1562859371627}}

iex(2)> EsCqrsMaestro.Counter.evaluate(%Maestro.Types.Command{aggregate_id: id, type: "increment_counter", data: %{}})

12:37:36.641 [debug] QUERY OK source="snapshots" db=2.4ms
SELECT s0."aggregate_id", s0."sequence", s0."body" FROM "snapshots" AS s0 WHERE (s0."sequence" > $1) AND (s0."sequence" <= $2) AND (s0."aggregate_id" = $3) [0, 2147483647, <<1, 107, 225, 173, 124, 107, 0, 0, 0, 0, 0, 0, 5, 71, 76, 225>>]
 
12:37:36.643 [debug] QUERY OK source="event_log" db=2.6ms
SELECT e0."timestamp", e0."aggregate_id", e0."sequence", e0."type", e0."body" FROM "event_log" AS e0 WHERE (e0."sequence" > $1) AND (e0."sequence" <= $2) AND (e0."aggregate_id" = $3) ORDER BY e0."timestamp" [0, 2147483647, <<1, 107, 225, 173, 124, 107, 0, 0, 0, 0, 0, 0, 5, 71, 76, 225>>]
 
12:37:36.675 [debug] QUERY OK db=0.2ms
begin []
 
12:37:36.692 [debug] QUERY ERROR db=5.6ms
INSERT INTO "event_log" ("aggregate_id","body","sequence","timestamp","type") VALUES ($1,$2,$3,$4,$5) [<<1, 107, 225, 173, 124, 107, 0, 0, 0, 0, 0, 0, 5, 71, 76, 225>>, %{}, 1, <<1, 107, 225, 174, 200, 133, 0, 0, 0, 0, 0, 0, 5, 71, 76, 225>>, "counter_incremented"]
 
12:37:36.692 [debug] QUERY OK db=0.2ms
rollback []
{:error,
 %UndefinedFunctionError{
   arity: 1,
   function: :encode_to_iodata!,
   message: nil,
   module: Jason,
   reason: nil
 },
 [
   {Jason, :encode_to_iodata!, [%{}], []},
   {Postgrex.DefaultTypes, :encode_params, 3,
    [file: 'lib/postgrex/type_module.ex', line: 721]},
   {DBConnection.Query.Postgrex.Query, :encode, 3,
    [file: 'lib/postgrex/query.ex', line: 62]},
   {DBConnection, :encode, 5, [file: 'lib/db_connection.ex', line: 1148]},
   {DBConnection, :run_prepare_execute, 5,
    [file: 'lib/db_connection.ex', line: 1246]},
   {DBConnection, :parsed_prepare_execute, 5,
    [file: 'lib/db_connection.ex', line: 540]},
   {DBConnection, :prepare_execute, 4,
    [file: 'lib/db_connection.ex', line: 533]},
   {Postgrex, :query, 4, [file: 'lib/postgrex.ex', line: 196]}
 ]}
```

Some of Maestro dependencies (like ecto) has Jason as optional dependency, it might have changed recently and broke Maestro.

As soon as we add Jason as an dependency to our project the problem is solved:

```Elixir
Interactive Elixir (1.8.2) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> {:ok, id} = EsCqrsMaestro.Counter.new()
{:ok, %HLClock.Timestamp{counter: 0, node_id: 88558817, time: 1562860067026}}

iex(2)> EsCqrsMaestro.Counter.evaluate(%Maestro.Types.Command{aggregate_id: id, type: "increment_counter", data: %{}})

12:47:57.360 [debug] QUERY OK source="snapshots" db=2.0ms
SELECT s0."aggregate_id", s0."sequence", s0."body" FROM "snapshots" AS s0 WHERE (s0."sequence" > $1) AND (s0."sequence" <= $2) AND (s0."aggregate_id" = $3) [0, 2147483647, <<1, 107, 225, 184, 24, 210, 0, 0, 0, 0, 0, 0, 5, 71, 76, 225>>]
 
12:47:57.364 [debug] QUERY OK source="event_log" db=2.9ms queue=0.1ms
SELECT e0."timestamp", e0."aggregate_id", e0."sequence", e0."type", e0."body" FROM "event_log" AS e0 WHERE (e0."sequence" > $1) AND (e0."sequence" <= $2) AND (e0."aggregate_id" = $3) ORDER BY e0."timestamp" [0, 2147483647, <<1, 107, 225, 184, 24, 210, 0, 0, 0, 0, 0, 0, 5, 71, 76, 225>>]
 
12:47:57.397 [debug] QUERY OK db=16.4ms queue=0.1ms
begin []
 
12:47:57.400 [debug] QUERY OK db=1.1ms
INSERT INTO "event_log" ("aggregate_id","body","sequence","timestamp","type") VALUES ($1,$2,$3,$4,$5) [<<1, 107, 225, 184, 24, 210, 0, 0, 0, 0, 0, 0, 5, 71, 76, 225>>, %{}, 1, <<1, 107, 225, 184, 65, 52, 0, 0, 0, 0, 0, 0, 5, 71, 76, 225>>, "counter_incremented"]
 
12:47:57.410 [debug] QUERY OK db=9.5ms
commit []
:ok
```

