### PR TITLE
Update mix task to generate migration on the right folder

### DIFF
--- a/lib/mix/tasks/maestro.create.event_store_migration.ex
+++ b/lib/mix/tasks/maestro.create.event_store_migration.ex
@@ -19,7 +19,6 @@ defmodule Mix.Tasks.Maestro.Create.EventStoreMigration do
     ]
 
   import Mix.Ecto, only: [parse_repo: 1, ensure_repo: 2]
-  import Ecto.Migrator, only: [migrations_path: 1]
 
   @change """
       create table(:event_log, primary_key: false) do

--- a/lib/mix/tasks/maestro.create.event_store_migration.ex
+++ b/lib/mix/tasks/maestro.create.event_store_migration.ex
@@ -49,13 +49,13 @@ defmodule Mix.Tasks.Maestro.Create.EventStoreMigration do
   def run(args) do
     [repo | _] = parse_repo(args)
     ensure_repo(repo, args)
-    path = migrations_path(repo)
 
     migration_name = parse_migration_name(args)
 
-    file = Path.join(path, "#{timestamp()}_#{migration_name}.exs")
+    file =
+      Path.join("priv/repo/migrations/", "#{timestamp()}_#{migration_name}.exs")
 
-    create_directory(path)
+    create_directory(Path.dirname(file))
 
     assigns = [
       mod: Module.concat([repo, Migrations, EventLogAndSnapshots]),


### PR DESCRIPTION
The migration generated from mix task was being created in the wrong folder. 

```Elixir
Joaos-MacBook-Pro:es_cqrs_maestro joaomoura$ mix maestro.create.event_store_migration --repo EsCqrsMaestro.Repo

 creating _build/dev/lib/es_cqrs_maestro/priv/repo/migrations
* creating _build/dev/lib/es_cqrs_maestro/priv/repo/migrations/20190711171921_event_log_and_snapshots.exs
```

After this update the migration is created in the folder priv\repo\migrations as Ecto expects:

```elixir
Joaos-MacBook-Pro:es_cqrs_maestro joaomoura$ mix maestro.create.event_store_migration
* creating priv/repo/migrations
* creating priv/repo/migrations/20190711174821_event_log_and_snapshots.exs
```