### PR TITLE
feat: switch to `:ok`/`:error` tuples, drop stacktraces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,3 @@ jobs:
 
       - name: Run credo
         run: mix credo --strict
-
-      - name: Run coveralls
-        run: mix coveralls.github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ for testing purposes only.
 ## Status
 [![Hex](http://img.shields.io/hexpm/v/maestro.svg?style=flat)](https://hex.pm/packages/maestro)
 [![Elixir CI](https://github.com/elixir-toniq/maestro/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/elixir-toniq/maestro/actions/workflows/elixir.yml)
-[![Coverage Status](https://coveralls.io/repos/github/elixir-toniq/maestro/badge.svg?branch=main)](https://coveralls.io/github/elixir-toniq/maestro?branch=master)
 
 Documentation is available [here](https://hexdocs.pm/maestro/).
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Documentation is available [here](https://hexdocs.pm/maestro/).
 
 ```elixir
 def deps do
-  [{:maestro, "~> 0.2"}]
+  [{:maestro, "~> 1.0"}]
 end
 ```
 
@@ -69,13 +69,14 @@ defmodule MyApp.Aggregate.Commands.IncrementCounter do
   alias Maestro.Types.Event
 
   def eval(aggregate, _command) do
-    [
-      %Event{
-        aggregate_id: aggregate.id,
-        type: "counter_incremented",
-        body: %{}
-      }
-    ]
+    {:ok,
+     [
+       %Event{
+         aggregate_id: aggregate.id,
+         type: "counter_incremented",
+         body: %{}
+       }
+     ]}
   end
 end
 

--- a/lib/maestro/aggregate/command_handler.ex
+++ b/lib/maestro/aggregate/command_handler.ex
@@ -11,9 +11,9 @@ defmodule Maestro.Aggregate.CommandHandler do
   @doc """
   Command handlers in maestro should implement an `eval` function that expects
   to receive the current `Root` object complete with sequence number and
-  aggregate ID and the incoming command. They should return a list of events or
-  raise an error which can be used to short circuit the command processing
-  cycle.
+  aggregate ID and the incoming command. They should return `{:ok, events}` on
+  success or `{:error, reason}` to reject the command.
   """
-  @callback eval(root(), command()) :: [uncommitted_event()]
+  @callback eval(root(), command()) ::
+              {:ok, [uncommitted_event()]} | {:error, any()}
 end

--- a/lib/maestro/aggregate/root.ex
+++ b/lib/maestro/aggregate/root.ex
@@ -49,8 +49,6 @@ defmodule Maestro.Aggregate.Root do
 
   @type id :: HLClock.Timestamp.t()
 
-  @type stack :: Exception.stacktrace()
-
   @type sequence :: non_neg_integer()
 
   @type command :: Maestro.Types.Command.t()
@@ -100,7 +98,7 @@ defmodule Maestro.Aggregate.Root do
           Root.persist_snapshot(snap)
         end
       rescue
-        err -> {:error, err, __STACKTRACE__}
+        err -> {:error, err}
       end
 
       def call(agg_id, msg) do
@@ -148,7 +146,7 @@ defmodule Maestro.Aggregate.Root do
         {:reply, {:ok, agg.state}, agg}
       rescue
         err ->
-          {:reply, {:error, err, __STACKTRACE__}, agg}
+          {:reply, {:error, err}, agg}
       end
 
       def handle_call(:get_current, _from, agg) do
@@ -158,29 +156,33 @@ defmodule Maestro.Aggregate.Root do
       def handle_call({:replay, seq}, _from, agg) do
         {:reply, {:ok, Root.replay(agg, seq)}, agg}
       rescue
-        err -> {:reply, {:error, err, __STACKTRACE__}, agg}
+        err -> {:reply, {:error, err}, agg}
       end
 
       def handle_call(:get_snapshot, _from, agg) do
         body = prepare_snapshot(agg.state)
         {:reply, {:ok, Root.to_snapshot(agg, body)}, agg}
       rescue
-        err -> {:reply, {:error, err, __STACKTRACE__}, agg}
+        err -> {:reply, {:error, err}, agg}
       end
 
       def handle_call({:eval_command, command, opts}, _from, agg) do
-        {:ok, agg, events} = Root.eval_command(agg, command)
+        case Root.eval_command(agg, command) do
+          {:ok, agg, events} ->
+            result =
+              case opts[:return] do
+                :state -> {:ok, agg.state}
+                :events -> {:ok, events}
+                _ -> :ok
+              end
 
-        result =
-          case opts[:return] do
-            :state -> {:ok, agg.state}
-            :events -> {:ok, events}
-            _ -> :ok
-          end
+            {:reply, result, agg}
 
-        {:reply, result, agg}
+          {:error, _reason} = error ->
+            {:reply, error, agg}
+        end
       rescue
-        err -> {:reply, {:error, err, __STACKTRACE__}, agg}
+        err -> {:reply, {:error, err}, agg}
       end
 
       def handle_info(:init, agg), do: {:noreply, Root.update_aggregate(agg)}
@@ -229,21 +231,21 @@ defmodule Maestro.Aggregate.Root do
   A (potentially) stale read of the aggregate's state. If you want to ensure the
   state is as up-to-date as possible, see `fetch/1`.
   """
-  @callback get(id()) :: {:ok, any()} | {:error, any(), stack()}
+  @callback get(id()) :: {:ok, any()} | {:error, any()}
 
   @doc """
   Forces the aggregate to retrieve any events. Since Maestro operates in a
   node-local manner, it's entirely possible some other node has processed
   commands/events.
   """
-  @callback fetch(id()) :: {:ok, any()} | {:error, any(), stack()}
+  @callback fetch(id()) :: {:ok, any()} | {:error, any()}
 
   @doc """
   Recover a past version of the aggregate's state by specifying a maximum
   sequence number. The aggregate's snapshot and any/all events will be used to
   get the state back to that point.
   """
-  @callback replay(id(), sequence()) :: {:ok, any()} | {:error, any(), stack()}
+  @callback replay(id(), sequence()) :: {:ok, any()} | {:error, any()}
 
   @type evaluate_opt :: {:return, :events | :state}
   @type evaluate_opts :: [evaluate_opt()]
@@ -255,20 +257,20 @@ defmodule Maestro.Aggregate.Root do
               :ok
               | {:ok, [Maestro.Types.Event.t()]}
               | {:ok, state :: any()}
-              | {:error, any(), stack()}
+              | {:error, any()}
 
   @callback evaluate(command(), evaluate_opts()) ::
               :ok
               | {:ok, [Maestro.Types.Event.t()]}
               | {:ok, state :: any()}
-              | {:error, any(), stack()}
+              | {:error, any()}
 
   @doc """
   Using the aggregate root's `prepare_snapshot` function, generate and store a
   snapshot. Useful if there are a lot of events, big events, or just a healthy
   amount of aggregate state to compose.
   """
-  @callback snapshot(id()) :: :ok | {:error, any(), stack()}
+  @callback snapshot(id()) :: :ok | {:error, any()}
 
   @doc """
   If you extend the aggregate to provide other functionality, `call` is
@@ -366,12 +368,16 @@ defmodule Maestro.Aggregate.Root do
 
   @doc false
   def eval_command(agg, command) do
-    with agg <- update_aggregate(agg),
-         com_module <- lookup_module(agg.command_prefix, command.type),
-         events <- com_module.eval(agg, command),
-         events <- prepare_events(agg, events),
-         agg <- persist_events(agg, command, events) do
-      {:ok, agg, events}
+    agg = update_aggregate(agg)
+    com_module = lookup_module(agg.command_prefix, command.type)
+
+    case com_module.eval(agg, command) do
+      {:ok, events} ->
+        events = prepare_events(agg, events)
+        persist_events(agg, command, events)
+
+      {:error, _reason} = error ->
+        error
     end
   end
 
@@ -393,15 +399,12 @@ defmodule Maestro.Aggregate.Root do
   defp persist_events(agg, command, events) do
     case Store.commit_all(events, agg.projections) do
       :ok ->
-        apply_events(agg, events)
+        {:ok, apply_events(agg, events), events}
 
       {:error, :retry_command} ->
-        {:ok, agg, _events} =
-          agg
-          |> update_aggregate()
-          |> eval_command(command)
-
         agg
+        |> update_aggregate()
+        |> eval_command(command)
     end
   end
 

--- a/lib/maestro/errors.ex
+++ b/lib/maestro/errors.ex
@@ -12,12 +12,3 @@ defmodule Maestro.InvalidHandlerError do
     """
   end
 end
-
-defmodule Maestro.InvalidCommandError do
-  @moduledoc """
-  The preferred exception for informing the client that their command was
-  rejected for any reason.
-  """
-
-  defexception message: ""
-end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,10 @@ defmodule Maestro.Mixfile do
         source_url: @source_url,
         extras: ["README.md"]
       ],
-      dialyzer: [ignore_warnings: "dialyzer.ignore-warnings"]
+      dialyzer: [
+        plt_add_apps: [:mix, :ex_unit],
+        flags: [:error_handling]
+      ]
     ]
   end
 
@@ -46,7 +49,7 @@ defmodule Maestro.Mixfile do
       {:castore, "~> 1.0", only: [:dev, :test]},
       {:credo, "~> 1.0", only: [:dev, :test]},
       {:stream_data, "~> 1.0", only: [:dev, :test]},
-      {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
+      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:benchee, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.16", only: :dev}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -21,14 +21,7 @@ defmodule Maestro.Mixfile do
         source_url: @source_url,
         extras: ["README.md"]
       ],
-      dialyzer: [ignore_warnings: "dialyzer.ignore-warnings"],
-      test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [
-        coveralls: :test,
-        "coveralls.html": :test,
-        "coveralls.post": :test,
-        "coveralls.github": :test
-      ]
+      dialyzer: [ignore_warnings: "dialyzer.ignore-warnings"]
     ]
   end
 
@@ -55,8 +48,7 @@ defmodule Maestro.Mixfile do
       {:stream_data, "~> 1.0", only: [:dev, :test]},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:benchee, "~> 1.0", only: :dev},
-      {:ex_doc, "~> 0.16", only: :dev},
-      {:excoveralls, "~> 0.8", only: :test}
+      {:ex_doc, "~> 0.16", only: :dev}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Maestro.Mixfile do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "1.0.0"
   @source_url "https://github.com/elixir-toniq/maestro"
 
   def project do

--- a/test/maestro/aggregate_test.exs
+++ b/test/maestro/aggregate_test.exs
@@ -10,7 +10,7 @@ defmodule Maestro.AggregateTest do
   alias Ecto.Adapters.SQL.Sandbox
   alias HLClock.Server, as: HLCServer
   alias Maestro.Aggregate.Root
-  alias Maestro.{InvalidCommandError, InvalidHandlerError}
+  alias Maestro.InvalidHandlerError
   alias Maestro.{Repo, SampleAggregate}
   alias Maestro.Types.{Command, Event}
 
@@ -126,7 +126,7 @@ defmodule Maestro.AggregateTest do
 
         case res do
           :ok -> :ok
-          {:error, err, stack} -> reraise err, stack
+          {:error, err} -> raise err
         end
       end
 
@@ -147,7 +147,7 @@ defmodule Maestro.AggregateTest do
         data: %{}
       }
 
-      {:error, err, _stack} = SampleAggregate.evaluate(com)
+      {:error, err} = SampleAggregate.evaluate(com)
 
       assert err == InvalidHandlerError.exception(type: "invalid")
 
@@ -168,12 +168,7 @@ defmodule Maestro.AggregateTest do
         data: %{"do_inc" => false}
       }
 
-      {:error, err, _stack} = SampleAggregate.evaluate(com)
-
-      assert err ==
-               InvalidCommandError.exception(
-                 message: "command incorrectly specified"
-               )
+      assert {:error, :incorrectly_specified} = SampleAggregate.evaluate(com)
     end
 
     test "handler raised an unexpected error" do
@@ -185,7 +180,7 @@ defmodule Maestro.AggregateTest do
         data: %{"raise" => true}
       }
 
-      {:error, err, _stack} = SampleAggregate.evaluate(com)
+      {:error, err} = SampleAggregate.evaluate(com)
 
       assert err ==
                ArgumentError.exception(
@@ -207,7 +202,7 @@ defmodule Maestro.AggregateTest do
         get_snapshot: fn _, _, _ ->
           raise(ConnectionError, "some")
         end do
-        {:error, err, _stack} = SampleAggregate.evaluate(com)
+        {:error, err} = SampleAggregate.evaluate(com)
         assert err == ConnectionError.exception("some")
       end
     end
@@ -231,18 +226,13 @@ defmodule Maestro.AggregateTest do
 
       :ok = SampleAggregate.evaluate(com)
 
-      {:error, err, _stack} = SampleAggregate.evaluate(com)
-
-      assert err ==
-               InvalidCommandError.exception(
-                 message: "altering names is prohibited"
-               )
+      assert {:error, :name_already_set} = SampleAggregate.evaluate(com)
 
       {:ok, agg_id_2} = SampleAggregate.new()
 
       com_2 = Map.put(com, :aggregate_id, agg_id_2)
 
-      {:error, err, _stack} = SampleAggregate.evaluate(com_2)
+      {:error, err} = SampleAggregate.evaluate(com_2)
 
       assert err.__struct__ == Ecto.ConstraintError
 

--- a/test/support/commands/conditional_increment.ex
+++ b/test/support/commands/conditional_increment.ex
@@ -3,9 +3,7 @@ defmodule Maestro.SampleAggregate.Commands.ConditionalIncrement do
 
   @behaviour Maestro.Aggregate.CommandHandler
 
-  alias Maestro.InvalidCommandError
-
   def eval(_aggregate, _com) do
-    raise InvalidCommandError, "command incorrectly specified"
+    {:error, :incorrectly_specified}
   end
 end

--- a/test/support/commands/decrement_counter.ex
+++ b/test/support/commands/decrement_counter.ex
@@ -9,12 +9,13 @@ defmodule Maestro.SampleAggregate.Commands.DecrementCounter do
   @behaviour Maestro.Aggregate.CommandHandler
 
   def eval(aggregate, _command) do
-    [
-      %Event{
-        aggregate_id: aggregate.id,
-        type: "counter_decremented",
-        body: %{"message" => "decrement"}
-      }
-    ]
+    {:ok,
+     [
+       %Event{
+         aggregate_id: aggregate.id,
+         type: "counter_decremented",
+         body: %{"message" => "decrement"}
+       }
+     ]}
   end
 end

--- a/test/support/commands/increment_counter.ex
+++ b/test/support/commands/increment_counter.ex
@@ -8,12 +8,13 @@ defmodule Maestro.SampleAggregate.Commands.IncrementCounter do
   @behaviour Maestro.Aggregate.CommandHandler
 
   def eval(aggregate, _command) do
-    [
-      %Event{
-        aggregate_id: aggregate.id,
-        type: "counter_incremented",
-        body: %{"message" => "increment"}
-      }
-    ]
+    {:ok,
+     [
+       %Event{
+         aggregate_id: aggregate.id,
+         type: "counter_incremented",
+         body: %{"message" => "increment"}
+       }
+     ]}
   end
 end

--- a/test/support/commands/name_counter.ex
+++ b/test/support/commands/name_counter.ex
@@ -8,20 +8,20 @@ defmodule Maestro.SampleAggregate.Commands.NameCounter do
 
   @behaviour Maestro.Aggregate.CommandHandler
 
-  alias Maestro.InvalidCommandError
   alias Maestro.Types.Event
 
   def eval(%{state: %{"name" => cur}}, _command) when is_binary(cur) do
-    raise InvalidCommandError, "altering names is prohibited"
+    {:error, :name_already_set}
   end
 
   def eval(aggregate, %{data: %{"name" => new_name}}) do
-    [
-      %Event{
-        aggregate_id: aggregate.id,
-        type: "counter_named",
-        body: %{"name" => new_name}
-      }
-    ]
+    {:ok,
+     [
+       %Event{
+         aggregate_id: aggregate.id,
+         type: "counter_named",
+         body: %{"name" => new_name}
+       }
+     ]}
   end
 end

--- a/test/support/commands/raise_command.ex
+++ b/test/support/commands/raise_command.ex
@@ -4,6 +4,7 @@ defmodule Maestro.SampleAggregate.Commands.RaiseCommand do
   @behaviour Maestro.Aggregate.CommandHandler
 
   @dialyzer {:nowarn_function, eval: 2}
+
   def eval(_aggregate, %{data: %{"raise" => _any}}) do
     raise ArgumentError, "commands can raise arbitrary exceptions as well"
   end

--- a/test/support/commands/raise_command.ex
+++ b/test/support/commands/raise_command.ex
@@ -3,6 +3,7 @@ defmodule Maestro.SampleAggregate.Commands.RaiseCommand do
 
   @behaviour Maestro.Aggregate.CommandHandler
 
+  @dialyzer {:nowarn_function, eval: 2}
   def eval(_aggregate, %{data: %{"raise" => _any}}) do
     raise ArgumentError, "commands can raise arbitrary exceptions as well"
   end


### PR DESCRIPTION
Based on observed adoption attempts, it became obvious that the two patterns of expecting implementers to `raise` and returning error triples were confusing and for little benefit. Switching to more standard Elixir developer ergonomics makes sense to me.

This is meant to be the first in a few DevEx focused PRs to make the core part of Maestro ready for adoption.